### PR TITLE
Minor fixes to parse_layout

### DIFF
--- a/kle2xy.py
+++ b/kle2xy.py
@@ -83,18 +83,9 @@ class KLE2xy(list):
                     if 'h' in key and key['h'] != Decimal(1):
                         current_key['height'] = Decimal(key['h'])
                     if 'a' in key:
-                        current_key['label_style'] = self.key_skel['label_style'] = int(key['a'])
-                        if current_key['label_style'] < 0:
-                            current_key['label_style'] = 0
-                        elif current_key['label_style'] > 9:
-                            current_key['label_style'] = 9
+                        current_key['label_style'] = self.key_skel['label_style'] = max(min(int(key['a']), 9), 0)
                     if 'f' in key:
-                        font_size = int(key['f'])
-                        if font_size > 9:
-                            font_size = 9
-                        elif font_size < 1:
-                            font_size = 1
-                        current_key['label_size'] = self.key_skel['label_size'] = font_size
+                        current_key['label_size'] = self.key_skel['label_size'] = max(min(int(key['f']), 9), 1)
                     if 'p' in key:
                         current_key['keycap_profile'] = self.key_skel['keycap_profile'] = key['p']
                     if 'c' in key:

--- a/kle2xy.py
+++ b/kle2xy.py
@@ -19,8 +19,7 @@ class KLE2xy(list):
             'label_color': 'black',
             'label_size': 3,
             'label_style': 4,
-            'width': Decimal('1'), 'height': Decimal('1'),
-            'x': Decimal('0'), 'y': Decimal('0')
+            'width': Decimal('1'), 'height': Decimal('1')
         }
         self.rows = Decimal(0)
         self.columns = Decimal(0)
@@ -62,8 +61,6 @@ class KLE2xy(list):
         current_key = self.key_skel.copy()
         current_row = Decimal(0)
         current_col = Decimal(0)
-        current_x = 0
-        current_y = self.key_width / 2
 
         if isinstance(layout[0], dict):
             self.attrs(layout[0])
@@ -99,10 +96,8 @@ class KLE2xy(list):
                         current_key['label_color'] = self.key_skel['label_color'] = key['t']
                     if 'x' in key:
                         current_col += Decimal(key['x'])
-                        current_x += Decimal(key['x']) * self.key_width
                     if 'y' in key:
                         current_row += Decimal(key['y'])
-                        current_y += Decimal(key['y']) * self.key_width
                     if 'd' in key:
                         current_key['decal'] = True
 
@@ -111,16 +106,11 @@ class KLE2xy(list):
                     current_key['row'] = round(current_row, 2)
                     current_key['column'] = round(current_col, 2)
 
-                    # Determine the X center
-                    x_center = (current_key['width'] * self.key_width) / 2
-                    current_x += x_center
-                    current_key['x'] = current_x
-                    current_x += x_center
-
-                    # Determine the Y center
-                    y_center = (current_key['height'] * self.key_width) / 2
-                    y_offset = y_center - (self.key_width / 2)
-                    current_key['y'] = (current_y + y_offset)
+                    # x,y (units mm) is the center of the key
+                    x_center = current_col + current_key['width'] / 2
+                    y_center = current_row + current_key['height'] / 2
+                    current_key['x'] = x_center * self.key_width
+                    current_key['y'] = y_center * self.key_width
 
                     # Tend to our row/col count
                     current_col += current_key['width']
@@ -136,8 +126,6 @@ class KLE2xy(list):
                     current_key = self.key_skel.copy()
 
             # Move to the next row
-            current_x = 0
-            current_y += self.key_width
             current_col = Decimal(0)
             current_row += Decimal(1)
             if current_row > self.rows:

--- a/kle2xy.py
+++ b/kle2xy.py
@@ -108,8 +108,8 @@ class KLE2xy(list):
 
                 else:
                     current_key['name'] = key
-                    current_key['row'] = current_row
-                    current_key['column'] = current_col
+                    current_key['row'] = round(current_row, 2)
+                    current_key['column'] = round(current_col, 2)
 
                     # Determine the X center
                     x_center = (current_key['width'] * self.key_width) / 2


### PR DESCRIPTION
- use min/max instead of if (ensure min/maxed number ends up in skel)
- round to 2 decimals for row, column
- calculate x, y instead of calculating them every time

This PR corresponds to;
- https://github.com/qmk/qmk_firmware/pull/8955
- https://github.com/qmk/qmk_firmware/pull/8931